### PR TITLE
Add tests for date_from_4bytes and fix month calculation

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,15 @@
+import runpy
+from datetime import datetime
+
+module = runpy.run_path('utec/utils/data.py')
+date_from_4bytes = module['date_from_4bytes']
+
+
+def test_date_from_4bytes_known_timestamp():
+    data = b'\x60\xdc\x92\x8b'
+    expected = datetime(2024, 3, 14, 9, 10, 11)
+    assert date_from_4bytes(data) == expected
+
+
+def test_date_from_4bytes_short_input_returns_none():
+    assert date_from_4bytes(b'\x01\x02') is None

--- a/utec/utils/data.py
+++ b/utec/utils/data.py
@@ -20,7 +20,7 @@ def date_from_4bytes(byte_array: bytes) -> Optional[datetime.datetime]:
     byte_to_int4 = struct.unpack('>I', byte_array[:4])[0]
     seconds = byte_to_int4 & 63
     year = ((byte_to_int4 >> 26) & 63) + 2000
-    month = ((byte_to_int4 >> 22) - 1) & 15
+    month = (byte_to_int4 >> 22) & 15
     day = (byte_to_int4 >> 17) & 31
     hour = (byte_to_int4 >> 12) & 31
     minute = (byte_to_int4 >> 6) & 63


### PR DESCRIPTION
## Summary
- fix month calculation in `date_from_4bytes`
- add new `tests/test_data.py` covering `date_from_4bytes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3f1fe87083248ed3fd46164b67cc