### PR TITLE
Fix default_factory for Event timestamp

### DIFF
--- a/utec/events.py
+++ b/utec/events.py
@@ -48,7 +48,7 @@ class Event:
     type: EventType
     source: Any
     data: Dict[str, Any] = field(default_factory=dict)
-    timestamp: float = field(default_factory=asyncio.get_event_loop().time)
+    timestamp: float = field(default_factory=lambda: asyncio.get_event_loop().time())
     
     def __post_init__(self):
         """Set default values."""


### PR DESCRIPTION
## Summary
- defer event loop creation for Event timestamp field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841b5dd409c8324bebdec91689f4d90