### PR TITLE
Maintain BLE scan cache

### DIFF
--- a/tests/test_ble_cache.py
+++ b/tests/test_ble_cache.py
@@ -1,0 +1,40 @@
+import asyncio
+import time
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+pytest.importorskip("bleak", reason="bleak not installed")
+pytest.importorskip("bleak_retry_connector", reason="bleak_retry_connector not installed")
+pytest.importorskip("Crypto", reason="pycryptodome not installed")
+pytest.importorskip("ecdsa", reason="ecdsa not installed")
+
+from utec.ble.device import UtecBleDevice
+
+
+@pytest.mark.asyncio
+async def test_scan_cache_pruned(monkeypatch):
+    device = UtecBleDevice(uid="1", password="1", mac_uuid="AA:BB:CC:DD:EE:FF", device_name="test")
+
+    past_time = time.time() - (device._scan_cache_ttl + 1)
+    device._scan_cache["AA:BB:CC:DD:EE:00"] = (past_time, object())
+
+    async def dummy_cb(addr):
+        return None
+
+    device.async_bledevice_callback = dummy_cb
+
+    async def dummy_discover(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr("utec.ble.device.BleakScanner.discover", dummy_discover)
+
+    async def dummy_get_device(address):
+        return None
+
+    monkeypatch.setattr("utec.ble.device.get_device", dummy_get_device)
+
+    await device._get_bledevice("AA:BB:CC:DD:EE:FF")
+    assert "AA:BB:CC:DD:EE:00" not in device._scan_cache

--- a/utec/ble/device.py
+++ b/utec/ble/device.py
@@ -422,6 +422,12 @@ class UtecBleDevice(BaseBleDevice):
             
             # Check cache first
             current_time = time.time()
+
+            # prune cache
+            expired = [addr for addr, (ts, _) in self._scan_cache.items()
+                       if current_time - ts >= self._scan_cache_ttl]
+            for addr in expired:
+                del self._scan_cache[addr]
             if address in self._scan_cache:
                 cache_time, device = self._scan_cache[address]
                 if current_time - cache_time < self._scan_cache_ttl:


### PR DESCRIPTION
## Summary
- prune expired scan entries in `_get_bledevice`
- add regression test for cache pruning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bb9e26e483249dc6a12296f28e0e