### PR TITLE
Fix lock command misreporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,12 +188,18 @@ class UtecHaBridge:
             else:
                 # Execute actual command
                 if command.upper() == "LOCK":
-                    await lock.async_lock(update=True)
-                    logger.info(f"Successfully locked {lock.name}")
-                    
+                    success = await lock.async_lock(update=True)
+                    if success:
+                        logger.info(f"Successfully locked {lock.name}")
+                    else:
+                        logger.error(f"Failed to lock {lock.name}")
+
                 elif command.upper() == "UNLOCK":
-                    await lock.async_unlock(update=True)
-                    logger.info(f"Successfully unlocked {lock.name}")
+                    success = await lock.async_unlock(update=True)
+                    if success:
+                        logger.info(f"Successfully unlocked {lock.name}")
+                    else:
+                        logger.error(f"Failed to unlock {lock.name}")
                     
                 else:
                     logger.warning(f"Unknown command: {command}")

--- a/utec/abstract.py
+++ b/utec/abstract.py
@@ -146,13 +146,21 @@ class BaseLock(BaseBleDevice):
     """Base class for lock devices."""
     
     @abstractmethod
-    async def async_unlock(self, update: bool = True) -> None:
-        """Unlock the lock."""
+    async def async_unlock(self, update: bool = True) -> bool:
+        """Unlock the lock.
+
+        Returns:
+            True if the command completed successfully, False otherwise.
+        """
         pass
     
     @abstractmethod
-    async def async_lock(self, update: bool = True) -> None:
-        """Lock the lock."""
+    async def async_lock(self, update: bool = True) -> bool:
+        """Lock the lock.
+
+        Returns:
+            True if the command completed successfully, False otherwise.
+        """
         pass
     
     @abstractmethod

--- a/utec/ble/lock.py
+++ b/utec/ble/lock.py
@@ -90,8 +90,12 @@ class UtecBleLock(UtecBleDevice, BaseLock):
             logger.error(f"Error creating lock from JSON: {str(e)}")
             raise
 
-    async def async_unlock(self, update: bool = True) -> None:
-        """Unlock the lock."""
+    async def async_unlock(self, update: bool = True) -> bool:
+        """Unlock the lock.
+
+        Returns:
+            True if the command completed successfully, False otherwise.
+        """
         logger.info(f"Unlocking {self.name}...")
         
         # Create unlock request with UID and password data
@@ -114,10 +118,14 @@ class UtecBleLock(UtecBleDevice, BaseLock):
         if update:
             self.add_request(UtecBleRequest(BLECommandCode.LOCK_STATUS))
 
-        await self.send_requests()
+        return await self.send_requests()
 
-    async def async_lock(self, update: bool = True) -> None:
-        """Lock the lock."""
+    async def async_lock(self, update: bool = True) -> bool:
+        """Lock the lock.
+
+        Returns:
+            True if the command completed successfully, False otherwise.
+        """
         logger.info(f"Locking {self.name}...")
         
         # Create lock request with UID and password data  
@@ -140,7 +148,7 @@ class UtecBleLock(UtecBleDevice, BaseLock):
         if update:
             self.add_request(UtecBleRequest(BLECommandCode.LOCK_STATUS))
 
-        await self.send_requests()
+        return await self.send_requests()
 
     async def async_reboot(self) -> bool:
         """Reboot the lock.


### PR DESCRIPTION
## Summary
- propagate success/failure from BLE operations
- update logging of lock/unlock commands to reflect actual result

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c7717138832491c967d2601665b0