### PR TITLE
Fix BLE connectivity: UUID filter, scan conflicts, stale paths

### DIFF
--- a/utec/ble/background_scanner.py
+++ b/utec/ble/background_scanner.py
@@ -113,13 +113,12 @@ class BleBackgroundScanner:
         self._start_time = time.time()
 
         # Create scanner with detection callback
+        # No service_uuids filter — some U-tec locks only advertise manufacturer
+        # data (0x0969) or device name, not the lock service UUID.
+        # Device validation happens in _is_utec_lock() instead.
         self._scanner = BleakScanner(
             detection_callback=self._detection_callback,
-            service_uuids=[
-                DeviceServiceUUID.LOCK.value,
-            ],
             scanning_mode="passive" if config.ble_scan_passive else "active",
-            # bluez=PASSIVE_SCANNER_ARGS if config.ble_scan_passive else None,
         )
 
         try:

--- a/utec/ble/device.py
+++ b/utec/ble/device.py
@@ -319,10 +319,25 @@ class UtecBleDevice(BaseBleDevice):
                                 )
                             ) from None
 
-                        logger.debug(f"[{self.mac_uuid}] Performing fresh scan before retry")
-                        device = await self._get_bledevice(self.mac_uuid)
+                        # Use BlueZ D-Bus lookup for a fresh device object.
+                        # After a failed connection, BlueZ may have removed the device
+                        # from managed objects. The background scanner's cached BLEDevice
+                        # has the same stale path, so get_device() is the right source.
+                        logger.debug(f"[{self.mac_uuid}] Refreshing device from BlueZ before retry")
+                        try:
+                            device = await asyncio.wait_for(get_device(self.mac_uuid), timeout=5.0)
+                        except Exception:
+                            device = None
                         if not device:
-                            logger.warning(f"[{self.mac_uuid}] Device not found during retry scan")
+                            logger.warning(f"[{self.mac_uuid}] Device not in BlueZ cache, waiting for re-registration")
+                            await asyncio.sleep(3.0)
+                            try:
+                                device = await asyncio.wait_for(get_device(self.mac_uuid), timeout=5.0)
+                            except Exception:
+                                device = None
+                        if not device:
+                            logger.warning(f"[{self.mac_uuid}] Device still not available, falling back to full lookup")
+                            device = await self._get_bledevice(self.mac_uuid)
                         await asyncio.sleep(config.ble_retry_delay)
 
             # Key exchange phase
@@ -470,92 +485,25 @@ class UtecBleDevice(BaseBleDevice):
                 except Exception as e:
                     logger.warning(f"[{self.mac_uuid}] Device callback error: {str(e)}")
             
-            # Use our own scanning method
-            async with self._scanner_lock:
-                logger.debug(f"[{self.mac_uuid}] Acquired scanner lock")
-                
-                # If we recently did a scan, wait a bit
-                if current_time - self._last_scan_time < 2:
-                    wait_time = 2 - (current_time - self._last_scan_time)
-                    logger.debug(f"[{self.mac_uuid}] Waiting {wait_time:.1f}s for Bluetooth to settle")
-                    await asyncio.sleep(wait_time)
-                
-                # Try discovery method first
-                try:
-                    logger.debug(f"[{self.mac_uuid}] Starting BLE discovery scan (timeout: {config.ble_scan_timeout}s)")
-                    scan_start = time.time()
-                    
-                    # Use the new method that returns both device and advertisement data
-                    discovered_devices_and_adv = await asyncio.wait_for(
-                        BleakScanner.discover(timeout=config.ble_scan_timeout, return_adv=True),
-                        timeout=config.ble_scan_timeout + 5.0
-                    )
-                    
-                    scan_elapsed = time.time() - scan_start
-                    logger.debug(f"[{self.mac_uuid}] Discovery scan completed in {scan_elapsed:.2f}s, found {len(discovered_devices_and_adv)} devices")
-                    
-                    # Look through discovered devices
-                    for device_address, (device, adv_data) in discovered_devices_and_adv.items():
-                        if device.address.upper() == address.upper():
-                            # Use RSSI from advertisement data instead of device.rssi
-                            rssi = adv_data.rssi if adv_data.rssi is not None else "unknown"
-                            logger.info(f"[{self.mac_uuid}] Device found in discovery: {device.name} (RSSI: {rssi})")
-                            
-                            # Update cache
-                            self._scan_cache[address] = (current_time, device)
-                            self._last_scan_time = current_time
-                            
-                            return device
-                    
-                    logger.debug(f"[{self.mac_uuid}] Device not found in discovery results")
-                    
-                    # If device not found via discovery, try direct method as fallback
-                    logger.debug(f"[{self.mac_uuid}] Trying direct device lookup")
-                    try:
-                        device = await asyncio.wait_for(get_device(address), timeout=3.0)
-                        if device:
-                            logger.info(f"[{self.mac_uuid}] Device found via direct lookup")
-                            
-                            # Update cache
-                            self._scan_cache[address] = (current_time, device)
-                            self._last_scan_time = current_time
-                            
-                            return device
-                    except asyncio.TimeoutError:
-                        logger.warning(f"[{self.mac_uuid}] Direct device lookup timed out")
-                    except Exception as e:
-                        logger.debug(f"[{self.mac_uuid}] Direct device lookup failed: {e}")
-                
-                except asyncio.TimeoutError:
-                    logger.error(f"[{self.mac_uuid}] BLE discovery scan timed out")
-                except Exception as e:
-                    logger.error(
-                        f"[{self.mac_uuid}] Error during device search: {e}"
-                    )
+            # Fall back to lightweight BlueZ D-Bus lookup (no scan needed).
+            # This avoids "Operation already in progress" conflicts with the
+            # background scanner which holds the adapter.
+            logger.debug(f"[{self.mac_uuid}] Trying BlueZ D-Bus lookup")
+            try:
+                device = await asyncio.wait_for(get_device(address), timeout=5.0)
+                if device:
+                    logger.info(f"[{self.mac_uuid}] Device found via BlueZ lookup")
+                    self._scan_cache[address] = (current_time, device)
+                    self._last_scan_time = current_time
+                    return device
+            except asyncio.TimeoutError:
+                logger.warning(f"[{self.mac_uuid}] BlueZ lookup timed out")
+            except Exception as e:
+                logger.debug(f"[{self.mac_uuid}] BlueZ lookup failed: {e}")
 
-                    if any(term in str(e).lower() for term in ["dbus", "org.bluez"]):
-                        logger.error(
-                            f"[{self.mac_uuid}] BlueZ may be unresponsive. Try 'bluetoothctl restart' or rebooting the system."
-                        )
-                    
-                    # For the specific "operation in progress" error, retry with escalating waits
-                    if "Operation already in progress" in str(e):
-                        for wait in (3, 7):
-                            logger.warning(f"[{self.mac_uuid}] BLE scan in progress, waiting {wait}s...")
-                            await asyncio.sleep(wait)
-                            try:
-                                device = await asyncio.wait_for(get_device(address), timeout=3.0)
-                                if device:
-                                    logger.info(f"[{self.mac_uuid}] Device found after retry")
-                                    self._scan_cache[address] = (current_time, device)
-                                    self._last_scan_time = current_time
-                                    return device
-                            except Exception:
-                                logger.debug(f"[{self.mac_uuid}] Retry after {wait}s wait failed")
-                
-                self._last_scan_time = current_time
-                logger.warning(f"[{self.mac_uuid}] Device not found after all attempts")
-                return None
+            self._last_scan_time = current_time
+            logger.warning(f"[{self.mac_uuid}] Device not found after all attempts")
+            return None
             
     async def _brc_get_lock_device(self) -> Optional[BLEDevice]:
         """Callback for bleak_retry_connector to get the lock device."""


### PR DESCRIPTION
## Summary
Three targeted fixes based on tracing production failures against the bleak_retry_connector source:

- **Remove `service_uuids` filter from background scanner** — Back Patio was found by the old unfiltered `BleakScanner.discover()` but invisible to the filtered background scanner (51s without discovery). Some U-tec locks advertise manufacturer data (0x0969) but not the lock service UUID.
- **Replace fallback `BleakScanner.discover()` with `get_device()`** — The full scan conflicts with the running background scanner for the BlueZ adapter ("Operation already in progress"). `get_device()` queries the BlueZ D-Bus cache without scanning.
- **Use `get_device()` in connection retry path** — After a timeout, BlueZ removes the device from managed objects. The background scanner's cached BLEDevice has the same stale D-Bus path, causing "device disappeared" on all retries. `get_device()` returns the current BlueZ-registered path, with a 3s wait for re-registration if needed.

Also corrected initial plan after discovering `ble_device_callback` is never called by BRC (dead parameter), and that increasing `max_attempts` alone won't fix stale-path failures.

## Test plan
- [x] All 20 tests pass
- [x] All files compile cleanly
- [ ] Deploy to Pi — verify Back Patio discovered by background scanner
- [ ] Verify no more "Operation already in progress" errors
- [ ] Verify Office door retries with fresh BlueZ paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)