### PR TITLE
Add LOCK_FILTER for multi-bridge deployments

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -27,6 +27,15 @@ MQTT_PASSWORD=your-mqtt-password
 # Minimum recommended: 60 seconds to avoid overwhelming devices
 UPDATE_INTERVAL=300
 
+# Lock filter - comma-separated list of lock names or MAC addresses
+# Only listed locks will be managed by this bridge instance.
+# Useful for multi-Pi setups where each Pi handles nearby locks.
+# Leave empty/commented to manage ALL discovered locks.
+# Examples:
+#   LOCK_FILTER=Front Door,Back Patio
+#   LOCK_FILTER=D0:2E:AB:85:71:1B,D0:2E:AB:77:DC:CA
+#LOCK_FILTER=
+
 # ============================================================================
 # NOTES
 # ============================================================================

--- a/main.py
+++ b/main.py
@@ -103,13 +103,29 @@ class UtecHaBridge:
                 return False
             
             logger.info("Discovering U-tec devices...")
-            self.locks = await utec.discover_devices(self.utec_email, self.utec_password)
-            
-            if not self.locks:
+            all_locks = await utec.discover_devices(self.utec_email, self.utec_password)
+
+            if not all_locks:
                 logger.warning("No U-tec devices found")
                 return False
-            
-            logger.info(f"Found {len(self.locks)} U-tec device(s)")
+
+            logger.info(f"Found {len(all_locks)} U-tec device(s)")
+
+            # Apply lock filter if configured
+            lock_filter = os.getenv('LOCK_FILTER', '').strip()
+            if lock_filter:
+                filters = [f.strip().upper() for f in lock_filter.split(',') if f.strip()]
+                self.locks = [
+                    lock for lock in all_locks
+                    if lock.mac_uuid.upper().replace(":", "_") in [f.replace(":", "_") for f in filters]
+                    or lock.name.upper() in filters
+                ]
+                skipped = len(all_locks) - len(self.locks)
+                logger.info(f"Lock filter active: managing {len(self.locks)} lock(s), skipping {skipped}")
+                for lock in self.locks:
+                    logger.info(f"  Managed: {lock.name} ({lock.mac_uuid})")
+            else:
+                self.locks = all_locks
             
             # Build device mapping for commands
             for lock in self.locks:


### PR DESCRIPTION
## Summary
- Adds `LOCK_FILTER` env var — comma-separated list of lock names or MAC addresses
- Only listed locks are managed (BLE, MQTT, commands). Unlisted locks are ignored entirely.
- Enables running multiple Pi bridges where each handles nearby locks without conflicts

**Example:** Pi near the back patio sets `LOCK_FILTER=Back Patio` and only manages that lock. The main Pi sets `LOCK_FILTER=Front Door,Office door` for the rest.

## Test plan
- [x] All 20 tests pass
- [x] Compiles cleanly
- [ ] Test with `LOCK_FILTER=Front Door` — verify only Front Door is managed
- [ ] Test with empty/unset `LOCK_FILTER` — verify all locks managed (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)