### PR TITLE
Pin bleak versions, fix null device crash, invalidate stale keys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@
 #   sudo apt-get install -y python3-dev gcc
 #
 aiohttp>=3.8.0
-bleak>=0.19.0
-bleak-retry-connector>=1.0.0
+bleak>=0.19.0,<1.0.0
+bleak-retry-connector>=1.0.0,<4.0.0
+dbus-fast>=2.0.0,<3.0.0
 ecdsa>=0.18.0
 pycryptodome>=3.18.0
 brotli

--- a/utec/ble/device.py
+++ b/utec/ble/device.py
@@ -338,6 +338,13 @@ class UtecBleDevice(BaseBleDevice):
                         if not device:
                             logger.warning(f"[{self.mac_uuid}] Device still not available, falling back to full lookup")
                             device = await self._get_bledevice(self.mac_uuid)
+                        if not device:
+                            logger.error(f"[{self.mac_uuid}] Device unavailable after all lookup methods, aborting retries")
+                            raise self.error(
+                                UtecBleNotFoundError(
+                                    f"Device {self.name}({self.mac_uuid}) not found after connection failure"
+                                )
+                            )
                         await asyncio.sleep(config.ble_retry_delay)
 
             # Key exchange phase
@@ -392,6 +399,11 @@ class UtecBleDevice(BaseBleDevice):
         except Exception as e:
             elapsed = time.time() - self._operation_start_time if self._operation_start_time else 0
             logger.error(f"[{self.mac_uuid}] Operation failed after {elapsed:.2f}s in phase '{self._current_operation}': {str(e)}")
+            # Invalidate cached key — if the key was stale, next attempt will re-negotiate
+            key_cache = get_key_cache()
+            if key_cache.get(self.mac_uuid):
+                key_cache.remove(self.mac_uuid)
+                logger.info(f"[{self.mac_uuid}] Invalidated cached encryption key after failure")
             return False
             
         finally:


### PR DESCRIPTION
## Summary
- **Pin bleak<1.0.0** — Bleak 3.0+ with BlueZ 5.82 (Debian Trixie) causes BLE connection timeouts with U-tec locks. Confirmed by deploying identical code on Bookworm (bleak 0.22.3, works) vs Trixie (bleak 3.0.1, fails). Also pins bleak-retry-connector<4.0 and dbus-fast<3.0.
- **Fix null device crash** — When all device lookup methods return None during connection retries, the code passed `None` to `establish_connection()`, crashing with `'NoneType' object has no attribute 'details'`. Now raises a clear `UtecBleNotFoundError` instead.
- **Invalidate key cache on failure** — A stale cached encryption key (from lock reset or firmware update) was silently reused for up to 24 hours. Now the cache is invalidated on any operation failure so the next attempt re-negotiates.

## Test plan
- [x] All 20 tests pass
- [x] Deployed on Bookworm Pi 5 — Back Patio connects successfully with pinned versions
- [x] Confirmed bleak 0.22.3 installs correctly with version constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)