### PR TITLE
Use stable per-bridge MQTT client_id to avoid stale-LWT race on reboot

### DIFF
--- a/utec/integrations/ha_mqtt.py
+++ b/utec/integrations/ha_mqtt.py
@@ -108,7 +108,8 @@ class UtecMQTTClient:
     
     def _create_client(self) -> mqtt.Client:
         """Create and configure MQTT client."""
-        client_id = f"utec-ha-{int(time.time())}"
+        # Stable id so a Pi reboot takes over the prior session instead of leaving it to time out and fire its LWT after the new "online" publish.
+        client_id = f"utec-ha-{self.bridge_id}"
 
         # Handle paho-mqtt version differences
         try:


### PR DESCRIPTION
## Summary

- Replaces the timestamp-based MQTT \`client_id\` with a stable per-bridge id (\`utec-ha-<bridge_id>\`).
- Fixes a race after a Pi reboot where the bridge availability topic was retained as \`offline\` ~90s post-boot, marking that Pi's locks \`unavailable\` in Home Assistant even though the bridge was happily publishing lock states.

## Root cause

When a Pi reboots, its previous TCP session sits orphaned on the broker until keepalive (60s) plus tolerance times out — call it ~90s. With a fresh timestamp-based \`client_id\` each restart, the broker treats the new connection as unrelated to the old session:

1. New process connects, publishes \`utec/bridge/<bridge_id>/availability = online\` retained — succeeds.
2. ~90s later the broker finally declares the old session dead and fires its LWT → publishes \`offline\` retained, clobbering the new \`online\`.
3. \`binary_sensor.utec_bridge_<bridge_id>_online\` flips off; locks become \`unavailable\` via \`availability_mode: all\`.

The per-lock availability topics aren't LWTs, so they survived — only the per-bridge availability got clobbered, which is enough to take the locks down.

## Fix

A stable per-bridge \`client_id\` causes the broker to perform a session takeover when the Pi reconnects: it disconnects the old session cleanly *without* firing its LWT, then the new session's \`online\` publish wins. \`bridge_id\` is already unique per Pi (sanitized hostname or \`BRIDGE_ID\` env), so two bridges can't collide.

## Test plan

- [x] Reproduced the symptom on a live Pi after a reboot — \`utec/bridge/utec_ble_bridge/availability\` retained as \`offline\` while bridge process was healthy and publishing lock states.
- [x] Manual restart of \`utec_library.service\` (no orphaned LWT in flight) restored \`online\` and HA picked it up immediately — confirms the on_connect publish path itself is sound and the only issue is the orphan LWT timing.
- [ ] Apply this patch on both Pis, reboot one, verify \`utec/bridge/<bridge_id>/availability\` stays \`online\` continuously and HA never marks the locks \`unavailable\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)